### PR TITLE
Cn address bug

### DIFF
--- a/lib/data_maker/cn/address.rb
+++ b/lib/data_maker/cn/address.rb
@@ -69,17 +69,15 @@ module DataMaker
 
         def address_string
           generate
-          translate
           build_address
         end
 
         def address_struct
           generate
-          translate
           OpenStruct.new(street_address: street_address,
-                         city:           city,
-                         district:       district,
-                         province:       province,
+                         city:           translate('city', city),
+                         district:       translate('district', district),
+                         province:       translate('province', province),
                          postal_code:    postal_code
                         )
         end
@@ -96,12 +94,9 @@ module DataMaker
 
         private
 
-        def translate
+        def translate(prefix, value)
           DataMaker::Config.locale = locale
-          values = { province: province, city: city, district: district }
-          values.each do |key, value|
-            self.send("#{key}=", DataMaker.translate(['data_maker', 'address', key, value].join(".")))
-          end
+          DataMaker.translate(['data_maker', 'address', prefix, value].join("."))
         end
 
         def validate
@@ -155,9 +150,9 @@ module DataMaker
         def build_address
           address = []
           address << street_address
-          address << city
-          address << district
-          address << province
+          address << translate('city', city)
+          address << translate('district', district) unless district.nil?
+          address << translate('province', province)
           address << postal_code
           address.compact.join(", ")
         end

--- a/lib/data_maker/version.rb
+++ b/lib/data_maker/version.rb
@@ -1,3 +1,3 @@
 module DataMaker
-  VERSION = '2.3.3'
+  VERSION = '2.3.4'
 end

--- a/spec/lib/data_maker/data_maker_spec.rb
+++ b/spec/lib/data_maker/data_maker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DataMaker do
 
   describe "#VERSION" do
     # For each iteration of a version this would always get changed.
-    let(:current_version) { "2.3.3" }
+    let(:current_version) { "2.3.4" }
 
     it { expect(described_class).to be_const_defined(:VERSION) }
     it { expect(described_class::VERSION).to eq(current_version) }


### PR DESCRIPTION
Fixed non postal code generation bug and when address is generated through address_string and there is no district for a city it would generate all the districts.