### PR TITLE
Use random time for CN:NIN

### DIFF
--- a/lib/data_maker/cn/nin.rb
+++ b/lib/data_maker/cn/nin.rb
@@ -21,8 +21,9 @@ module DataMaker
         private
 
         def national_id_number
-          birthdate = rand(1920..1998).to_s + rand(1..12).to_s.rjust(2, '0') + rand(1..30).to_s.rjust(2, '0')
-          base_number = rand(10 ** 6).to_s.rjust(6, '0') + birthdate + rand(10 ** 3).to_s.rjust(3, '0')
+          birthdate = time_rand
+          birthdate_string = birthdate.year.to_s + birthdate.month.to_s.rjust(2, '0') + birthdate.day.to_s.rjust(2, '0')
+          base_number = rand(10 ** 6).to_s.rjust(6, '0') + birthdate_string + rand(10 ** 3).to_s.rjust(3, '0')
           weights = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2]
           summod = [1, 0, "X", 9, 8, 7, 6, 5, 4, 3, 2]
           checksum = 0
@@ -30,6 +31,10 @@ module DataMaker
             checksum += (weight * base_number[i].to_i)
           end
           base_number + summod[(checksum % 11)].to_s
+        end
+
+        def time_rand from = 0.0, to = Time.new(1998)
+          Time.at(from + rand * (to.to_f - from.to_f))
         end
       end
     end

--- a/lib/data_maker/version.rb
+++ b/lib/data_maker/version.rb
@@ -1,3 +1,3 @@
 module DataMaker
-  VERSION = '2.5.2'
+  VERSION = '2.5.3'
 end

--- a/spec/lib/data_maker/data_maker_spec.rb
+++ b/spec/lib/data_maker/data_maker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe DataMaker do
 
   describe "#VERSION" do
     # For each iteration of a version this would always get changed.
-    let(:current_version) { "2.5.2" }
+    let(:current_version) { "2.5.3" }
 
     it { expect(described_class).to be_const_defined(:VERSION) }
     it { expect(described_class::VERSION).to eq(current_version) }


### PR DESCRIPTION
Use a random time for national ID to avoid parse errors.